### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server for controlling [OmniFocus](https://www.omnigroup.com/omnifocus) from VS Code, the command line, or any MCP-compatible client. This tool enables automation and management of your OmniFocus tasks, projects, and tags using natural language and programmable interfaces.
 
+<a href="https://glama.ai/mcp/servers/@someposer/mcp-omnifocus">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@someposer/mcp-omnifocus/badge" alt="OmniFocus MCP server" />
+</a>
+
 ## Features
 
 - List all tasks, projects, tags, and perspectives in OmniFocus


### PR DESCRIPTION
This PR adds a badge for the [MCP OmniFocus](https://glama.ai/mcp/servers/@someposer/mcp-omnifocus) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@someposer/mcp-omnifocus">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@someposer/mcp-omnifocus/badge" alt="OmniFocus MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.